### PR TITLE
Refactor tealdbg-tutorial to isolate dependencies and generated data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 *.tok
 *.lsig
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+generated-data/

--- a/tealdbg-tutorial/README.md
+++ b/tealdbg-tutorial/README.md
@@ -9,8 +9,8 @@ This document walks through some steps on using `tealdbg` using the Chrome Devel
 The included script, `tealdbg_deploy.py`, creates the app, then calls it in a group transaction where the first transaction is a payment to the app address and the second transaction is the app call. Then, it generates a debugger context using dryrun through `sandbox`. 
 
 ## Debugging a TEAL app
-* Start `sandbox` if you haven't done so. In `tealdbg_deploy.py`, set your path to sandbox and run the script to deploy the example app. The script will automatically save a `signed_txn.txn` file and the debugging context `dryrun_txn.msgp` in the working directory. 
+* Start `sandbox` if you haven't done so. Export `SANDBOX_PATH` pointing to your _sandbox_ directory.  Run the script to deploy the example app. The script will automatically save a `signed_txn.txn` file and the debugging context `dryrun_txn.msgp` in the `generated-data/`.
 * Run `tealdbg`, e.g. from this directory, run: 
-```tealdbg debug some_itxns.teal -d dryrun_txn.msgp --group-index 1 -v```
-* Open a Chrome based browser and go to: `chrome://inspect/#devices`. Press `Configure...` and add `localhost:9392`. This is the default port for tealdbg, but double check the tealdbg output to make sure this is the case. 
+```tealdbg debug some_itxns.teal -d generated/data/dryrun_txn.msgp --group-index 1 -v```
+* Open a Chrome based browser and go to: `chrome://inspect/#devices`. Press `Configure...` and add `127.0.0.1:9392`. This is the default port for tealdbg, but double check the tealdbg output to make sure this is the case.
 * Open the CDT session either through Chrome or copying the link that is outputted on the tealdbg (it should start with `devtools://devtools`).

--- a/tealdbg-tutorial/requirements.txt
+++ b/tealdbg-tutorial/requirements.txt
@@ -1,0 +1,6 @@
+cffi==1.15.0
+msgpack==1.0.3
+py-algorand-sdk==1.9.0
+pycparser==2.21
+pycryptodomex==3.14.0
+PyNaCl==1.5.0

--- a/tealdbg-tutorial/tealdbg_deploy.py
+++ b/tealdbg-tutorial/tealdbg_deploy.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from pathlib import Path
 import pty
 from random import randrange
 import subprocess
@@ -9,8 +10,7 @@ from algosdk.future import transaction
 from algosdk.v2client import algod, indexer
 
 
-SANDBOX_PATH = ""  # Your sandbox path here
-
+sandbox_exec = Path(os.environ['SANDBOX_PATH']) / "sandbox"
 
 def create_algod_client():
     return algod.AlgodClient(
@@ -33,7 +33,7 @@ def compile_program(client, source_code):
 
 def get_sandbox_account():
     stdout = subprocess.run(
-        [SANDBOX_PATH, "goal", "account", "list"],
+        [sandbox_exec, "goal", "account", "list"],
         stdin=pty.openpty()[1],
         capture_output=True,
         text=True,
@@ -44,7 +44,7 @@ def get_sandbox_account():
 def export_sandbox_account():
     genesis_addr = get_sandbox_account()
     stdout = subprocess.run(
-        [SANDBOX_PATH, "goal", "account", "export", "-a", genesis_addr],
+        [sandbox_exec, "goal", "account", "export", "-a", genesis_addr],
         stdin=pty.openpty()[1],
         capture_output=True,
         text=True,
@@ -77,15 +77,19 @@ def create_transient_account(client, sender, private_key):
     return sk, pk
 
 
-def create_debugger_context(
-    context_file="signed_txn.txn", output_file="dryrun_txn.msgp"
-):
-    sandbox_copyto = f"{SANDBOX_PATH} copyTo {context_file}"
-    dry_run_command = f"{SANDBOX_PATH} goal clerk dryrun -t {context_file} --dryrun-dump -o {output_file}"
-    sandbox_copyfrom = f"{SANDBOX_PATH} copyFrom {output_file}"
+def create_debugger_context(output_path, context_file, output_file):
+    sandbox_copyto = f"{sandbox_exec} copyTo {context_file}"
+    dry_run_command = f"{sandbox_exec} goal clerk dryrun -t {context_file} --dryrun-dump -o {output_file}"
+    sandbox_copyfrom = f"{sandbox_exec} copyFrom {output_file}"
+
+    # Change CWD to structure copy commands in a sanbox container compliant manner.
+    cwd = os.getcwd()
+    os.chdir(output_path)
+
     os.system(sandbox_copyto)
     os.system(dry_run_command)
     os.system(sandbox_copyfrom)
+    os.chdir(cwd)
 
 
 # Create global account and clients
@@ -95,7 +99,7 @@ params = client.suggested_params()
 
 # Creates a stateful app for testing
 # The TEAL code for the app can be changed in sample-teal/
-def create_test_app():
+def create_test_app(output_path):
 
     # Create transient
     sk, pk = create_transient_account(client, sender, private_key)
@@ -137,8 +141,7 @@ def create_test_app():
     tx_id = signed_txn.transaction.get_txid()
 
     # Write stxn to file
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    transaction.write_to_file([signed_txn], dir_path + "/signed_txn_create.txn")
+    transaction.write_to_file([signed_txn], output_path / "signed_txn_create.txn")
 
     # Send transaction
     client.send_transactions([signed_txn])
@@ -152,7 +155,7 @@ def create_test_app():
     return app_id
 
 
-def call_app(app_id):
+def call_app(app_id, output_path):
     txn1 = transaction.PaymentTxn(
         sender,
         params,
@@ -177,15 +180,19 @@ def call_app(app_id):
     tx_id = stxns[0].get_txid()
 
     # Write stxn to file
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    transaction.write_to_file(stxns, dir_path + "/signed_txn.txn")
+    transaction.write_to_file(stxns, output_path / "signed_txn.txn")
 
     # Send transaction
     client.send_transactions(stxns)
     resp = transaction.wait_for_confirmation(client, tx_id, 5)
     print(f"Response: {resp}")
 
+output_path = Path(os.path.dirname(os.path.realpath(__file__))) / "generated-data"
+output_path.mkdir(exist_ok=True)
 
-app_id = create_test_app()
-call_app(app_id)
-create_debugger_context()
+app_id = create_test_app(output_path)
+call_app(app_id, output_path)
+create_debugger_context(
+    output_path=output_path,
+    context_file="signed_txn.txn",
+    output_file="dryrun_txn.msgp")


### PR DESCRIPTION
Optionally proposes refactorings to tealdbg-tutorial aimed at isolating dependencies and minimizing source control changes.

Specifically, the PR:
* Adds a `requirements.txt` to support a Python virtual environment.
* Uses an environment variable to source _sandbox_ path instead of requiring source code changes.
* Defines a `generated-data` dir to store all output data along with a gitignore to avoid versioning generated data. 

Minor note:  I had to point CDT to 127.0.0.1 instead of localhost.  From `tealdbg` docs, it seems 127.0.0.1 is the default.  Might be OS specific.  I can revert that part of the note if you prefer.
